### PR TITLE
update pyfast to produce plots and case summary

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -434,7 +434,7 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
-max-line-length=79
+max-line-length=88
 
 # Maximum number of lines in a module
 max-module-lines=1000

--- a/pyFAST/__init__.py
+++ b/pyFAST/__init__.py
@@ -6,6 +6,7 @@ import os
 from pyfast import utilities
 
 from .executor import Executor
+from .case_list import CASE_LIST
 
 ROOT = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(ROOT, "..", "VERSION")) as version_file:

--- a/pyFAST/utilities/__init__.py
+++ b/pyFAST/utilities/__init__.py
@@ -1,7 +1,7 @@
 """Initializes the utility functions"""
 
 
-from pyfast.utilities.norm import calculate_norms
+from pyfast.utilities.norm import calculate_norms, pass_regression_test
 from pyfast.utilities.fast_io import load_output
-from pyfast.utilities.plotting import create_case_summary
+from pyfast.utilities.plotting import plot_error, create_case_summary
 from pyfast.utilities.utilities import *

--- a/pyFAST/utilities/fast_io.py
+++ b/pyFAST/utilities/fast_io.py
@@ -52,7 +52,7 @@ def load_output(filename):
             return load_binary_output(filename)
         elif "out" in filename:
             try:
-                print(f.readline())
+                _ = f.readline()
             except UnicodeDecodeError:
                 return load_binary_output(filename)
     return load_ascii_output(filename) + (np.ones(1),)

--- a/pyFAST/utilities/norm.py
+++ b/pyFAST/utilities/norm.py
@@ -7,6 +7,7 @@ from typing import List
 
 import numpy as np
 import numpy.linalg as LA
+
 from pyfast.utilities.fast_io import load_output
 from pyfast.utilities.utilities import validate_file
 
@@ -53,7 +54,7 @@ def pass_regression_test(norm: np.ndarray, tolerance: float) -> bool:
     bool
         Indicator for if the regression test norm passed.
     """
-    return max(norm) < tolerance
+    return norm.max() < tolerance
 
 
 # The Norms
@@ -69,8 +70,6 @@ def max_norm(baseline: np.ndarray, test: np.ndarray) -> np.ndarray:
         Baseline data.
     test : np.ndarray
         Test-produced data.
-    abs_val : bool
-        Indicator to use absolute value.
     axis : int, optional
         Axis for computing the norm, by default 0.
 
@@ -83,7 +82,7 @@ def max_norm(baseline: np.ndarray, test: np.ndarray) -> np.ndarray:
     return LA.norm(diff(baseline, test, True), np.inf, axis=0)
 
 
-def l2_norm(baseline: np.ndarray, test: np.ndarray) -> np.ndarray:
+def l2_norm(baseline: np.ndarray, test: np.ndarray, abs_val: bool = True) -> np.ndarray:
     """
     Compute the L2 norm of the difference between baseline and test results.
 
@@ -93,8 +92,6 @@ def l2_norm(baseline: np.ndarray, test: np.ndarray) -> np.ndarray:
         Baseline data.
     test : np.ndarray
         Test-produced data.
-    abs_val : bool, optional
-        Indicator to use absolute value, by default True.
     axis : int, optional
         Axis for computing the norm, by default 0.
 
@@ -104,7 +101,7 @@ def l2_norm(baseline: np.ndarray, test: np.ndarray) -> np.ndarray:
         L2 norm of the differene betwen baseline and test data.
     """
 
-    return LA.norm(diff(baseline, test, True), 2, axis=0)
+    return LA.norm(diff(baseline, test, abs_val), 2, axis=0)
 
 
 def relative_l2_norm(baseline: np.ndarray, test: np.ndarray) -> np.ndarray:
@@ -129,7 +126,7 @@ def relative_l2_norm(baseline: np.ndarray, test: np.ndarray) -> np.ndarray:
         Relative L2 norm of the differene betwen baseline and test data.
     """
 
-    norm_diff = l2_norm(baseline, test, abs_val=False, axis=0)
+    norm_diff = l2_norm(baseline, test, abs_val=False)
     norm_baseline = LA.norm(baseline, 2, axis=0)
 
     # Replace zeros with a small value before division
@@ -152,8 +149,6 @@ def max_norm_over_range(baseline: np.ndarray, test: np.ndarray) -> np.ndarray:
         Baseline data.
     test : np.ndarray
         Test-produced data.
-    abs_val : bool, optional
-        Indicator to use absolute value, by default True.
     axis : int, optional
         Axis for computing the norm, by default 0.
 
@@ -164,7 +159,7 @@ def max_norm_over_range(baseline: np.ndarray, test: np.ndarray) -> np.ndarray:
     """
 
     ranges = diff(baseline.max(axis=0), baseline.min(axis=0), True)
-    norm = max_norm(baseline, test, abs_val, axis=0)
+    norm = max_norm(baseline, test)
 
     ix_no_diff = ranges >= 1
     norm[ix_no_diff] = norm[ix_no_diff] / ranges[ix_no_diff]
@@ -202,7 +197,7 @@ def calculate_norms(
     """
 
     norm_results = np.hstack(
-        (NORM_MAP[norm_type](baseline, test).reshape(-1, 1) for norm_type in norms)
+        list(NORM_MAP[norm_type](baseline, test).reshape(-1, 1) for norm_type in norms)
     )
     return norm_results
 

--- a/pyFAST/utilities/utilities.py
+++ b/pyFAST/utilities/utilities.py
@@ -132,5 +132,3 @@ def run_openfast_case(
         f"{code}{elapsed.rjust(8)} seconds"
     )
     print(message, flush=True)
-
-    return code

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "numpy",
-        "bokeh",
+        "bokeh==1.4.0",
         "pre-commit",
         "black",
         "isort",


### PR DESCRIPTION
Updates the code base to be fully functioning to run openfast, plot the results, and create a case summary.

For instance running `python pyfast -e <path>/OpenFAST/build/glue-codes/openfast/openfast <path>/OpenFAST/build/modules/beamdyn/beamdyn_driver -s <path>/OpenFAST -c gnu --plot 2 -r all` will produce:
![image](https://user-images.githubusercontent.com/13874373/70100033-cc76ed80-15ed-11ea-9ee4-c5646ea41810.png)
